### PR TITLE
Delete TestTime & License lines

### DIFF
--- a/kernel/infiniband/demo/testinfo.desc
+++ b/kernel/infiniband/demo/testinfo.desc
@@ -4,9 +4,7 @@ TestVersion:     0.1
 Path:            /mnt/tests/kernel/infiniband/demo
 Description:     simple rdma test for fsdp demo
 Type:            demo_only
-TestTime:        1h
 RunFor:          demo
 Priority:        Normal
-License:         GPLv2+
 Destructive:     no
 Releases:        -RHEL Fedora


### PR DESCRIPTION
Since 'make bkradd' fails due to TestTime & License lines, deleting
these lines.